### PR TITLE
Fix glass pane transparency w/ 5.9 clients

### DIFF
--- a/modules/historic/nodes.lua
+++ b/modules/historic/nodes.lua
@@ -63,6 +63,7 @@ minetest.register_node("cottages:glass_pane", {
 	tiles = { "cottages_glass_pane.png" },
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	groups = { snappy = 2, choppy = 2, oddly_breakable_by_hand = 2 },
 	node_box = {
 		type = "fixed",
@@ -85,6 +86,7 @@ minetest.register_node("cottages:glass_pane_side", {
 	tiles = { "cottages_glass_pane.png" },
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	groups = { snappy = 2, choppy = 2, oddly_breakable_by_hand = 2 },
 	node_box = {
 		type = "fixed",


### PR DESCRIPTION
Why? Please read https://github.com/Archtec-io/bugtracker/issues/137

Screenshot in mt 5.9 w/o my patch:
![Screenshot_20231217_121702](https://github.com/fluxionary/minetest-cottages/assets/89982526/c17f151a-ee72-4a97-917a-2407fdd80914)

@fluxionary ping